### PR TITLE
chore(actions): add support for Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby-version: ["3.1", "3.2", "3.3"]
+        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Adds support for Ruby 3.4 to the GitHub Actions workflow matrix. Version 3.1 has been maintained as it is still supported until the end of March.